### PR TITLE
Remove Air and Sea Schengen mention for Romania and Bulgaria

### DIFF
--- a/_pages/about/visa.md
+++ b/_pages/about/visa.md
@@ -18,10 +18,9 @@ Simply a valid passport is required to enter Austria. In case of doubt please co
 
 Current member countries of the Schengen treaty are:
 
-Austria, Belgium, Bulgaria\*\*, Croatia, Czech Republic, Denmark, Estonia, Finland, France, Germany, Greece, Hungary, Iceland\*, Italy, Latvia, Liechtenstein\*, Lithuania, Luxembourg, Malta, Netherlands, Norway\*, Poland, Portugal, Romania\*\*, Slovakia, Slovenia, Spain, Sweden, and Switzerland\*.
+Austria, Belgium, Bulgaria, Croatia, Czech Republic, Denmark, Estonia, Finland, France, Germany, Greece, Hungary, Iceland\*, Italy, Latvia, Liechtenstein\*, Lithuania, Luxembourg, Malta, Netherlands, Norway\*, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden, and Switzerland\*.
 
-\* non-EU members.     
-\*\* Schengen Air & Sea agreement.    
+\* non-EU members.
 
 ## Who needs a visa?
 


### PR DESCRIPTION
On 1 January 2025, Romania and Bulgaria became full members of the Schengen Area after the checks on persons at the internal land borders were lifted.

https://home-affairs.ec.europa.eu/news/bulgaria-and-romania-join-schengen-area-2025-01-03_en